### PR TITLE
xpmem_detach: fix deadlock

### DIFF
--- a/kernel/xpmem_attach.c
+++ b/kernel/xpmem_attach.c
@@ -583,12 +583,6 @@ xpmem_detach(u64 at_vaddr)
 
 	vma->vm_private_data = NULL;
 
-	/* NTH: drop the current mm semaphore before calling vm_munmap (which will
-	 * call down_write on the same semaphore) */
-	up_write(&current->mm->mmap_sem);
-	ret = vm_munmap(vma->vm_start, att->at_size);
-	DBUG_ON(ret != 0);
-
 	att->flags &= ~XPMEM_FLAG_VALIDPTEs;
 
 	spin_lock(&ap->lock);
@@ -596,6 +590,13 @@ xpmem_detach(u64 at_vaddr)
 	spin_unlock(&ap->lock);
 
 	mutex_unlock(&att->mutex);
+
+
+	/* NTH: drop the current mm semaphore before calling vm_munmap (which will
+	 * call down_write on the same semaphore) */
+	up_write(&current->mm->mmap_sem);
+	ret = vm_munmap(vma->vm_start, att->at_size);
+	DBUG_ON(ret != 0);
 
 	xpmem_att_destroyable(att);
 

--- a/kernel/xpmem_private.h
+++ b/kernel/xpmem_private.h
@@ -58,6 +58,7 @@
  *     2.6.2  Fix race in xpmem_open
  *     2.6.3  Fix bugs introduced in 2.6.2 that worked with 3.x but
  *            not 4.x kernels.
+ *     2.6.4  Fix hold-and-wait deadlock on detach.
  *
  * This int constant has the following format:
  *
@@ -69,7 +70,7 @@
  *       minor - minor revision number (16-bits)
  */
 #define XPMEM_CURRENT_VERSION		0x00026003
-#define XPMEM_CURRENT_VERSION_STRING	"2.6.3"
+#define XPMEM_CURRENT_VERSION_STRING	"2.6.4"
 
 #define XPMEM_MODULE_NAME "xpmem"
 


### PR DESCRIPTION
I made modifications to the detach code to use vm_munmap instead of
the non-exported do_munmap call. This required dropping the mmap
semaphore before calling vm_munmap. Unfortunately this causes hold and
wait with xpmem_clear_PTEs_of_att. If the detach thread goes to sleep
between dropping the semaphore re-acquiring it and a thread in
xpmem_clear_PTEs_of_att acquires the semaphore then we have one thread
with the mmap semaphore trying to get the attachment lock and another
thread with the attachement lock trying to get the mmap
semaphore. Fixed the issue by clearing the attachment state and
dropping the attachment lock before dropping the mmap semaphore.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>