### PR TITLE
kernel: add support for Linux v4.6.x

### DIFF
--- a/kernel/xpmem_attach.c
+++ b/kernel/xpmem_attach.c
@@ -5,7 +5,7 @@
  *
  * Copyright (c) 2004-2007 Silicon Graphics, Inc.  All Rights Reserved.
  * Copyright 2010,2012 Cray Inc. All Rights Reserved
- * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  */
 
@@ -294,7 +294,11 @@ out_1:
 				       "%ld != %ld\n", old_pfn, pfn);
 			}
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
+			put_page(pfn_to_page(pfn));
+#else
 			page_cache_release(pfn_to_page(pfn));
+#endif
 			atomic_dec(&seg->tg->n_pinned);
 			atomic_inc(&xpmem_my_part->n_unpinned);
 			goto out;

--- a/kernel/xpmem_pfn.c
+++ b/kernel/xpmem_pfn.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2004-2007 Silicon Graphics, Inc.  All Rights Reserved.
  * Copyright 2009, 2014 Cray Inc. All Rights Reserved
  * Copyright 2016 ARM Inc. All Rights Reserved
- * Copyright (c) 2016      Nathan Hjelm <hjelmn@cs.unm.edu>
+ * Copyright (c) 2016-2017 Nathan Hjelm <hjelmn@cs.unm.edu>
  */
 
 /*
@@ -264,7 +264,11 @@ xpmem_unpin_pages(struct xpmem_segment *seg, struct mm_struct *mm,
 			XPMEM_DEBUG("pfn=%llx, vaddr=%llx, n_pgs=%d",
 					pfn, vaddr, n_pgs);
 			page = virt_to_page(__va(pfn << PAGE_SHIFT));
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
+			put_page(page);
+#else
 			page_cache_release(page);
+#endif
 			n_pgs_unpinned++;
 			vaddr += PAGE_SIZE;
 			n_pgs--;


### PR DESCRIPTION
The page_cache_release call was replaced by put_page in Linux v4.6.0.

Signed-off-by: Nathan Hjelm <hjelmn@me.com>