### PR TITLE
install module in <prefix>/lib/modules/<linux_release>

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ script:
         - for file in $(ls linux-headers-*) ; do dpkg -x $file linux-headers ; done
         - ./configure --prefix=/tmp/xpmem --with-default-prefix=/tmp/xpmem --with-module=/tmp/xpmem/share/modules/xpmem --with-kerneldir=$PWD/linux-headers/usr/src/linux-headers-$(uname -r)
         - make -j4 ; sudo make install
-        - sudo insmod /tmp/xpmem/lib/module/xpmem.ko ; sleep 1 ; sudo chmod 666 /dev/xpmem
+        - sudo insmod /tmp/xpmem/lib/modules/$(uname -r)/xpmem.ko ; sleep 1 ; sudo chmod 666 /dev/xpmem
         - make check

--- a/kernel/Makefile.am
+++ b/kernel/Makefile.am
@@ -1,6 +1,6 @@
 AM_CPPFLAGS = -I@top_srcdir@/include
 
-moduledir = $(libdir)/module
+moduledir = $(libdir)/modules/@kernelvers@/
 KERNEL_PATH=@kerneldir@
 init_SCRIPTS = xpmem
 MODULE=xpmem.ko

--- a/m4/ac_path_kernel_source.m4
+++ b/m4/ac_path_kernel_source.m4
@@ -2,7 +2,7 @@
 ## additional m4 macros
 ##
 ## (C) 1999 Christoph Bartelmus (lirc@bartelmus.de)
-## (C) 2016 Nathan Hjelm
+## (C) 2016-2018 Nathan Hjelm
 ##
 
 
@@ -45,12 +45,25 @@ AC_DEFUN([AC_PATH_KERNEL_SOURCE],
 [
   AC_CHECK_PROG(ac_pkss_mktemp,mktemp,yes,no)
   AC_PROVIDE([AC_PATH_KERNEL_SOURCE])
-  AC_MSG_CHECKING(for Linux kernel sources)
+  AC_MSG_CHECKING([for Linux kernel sources])
+  kernelvers=$(uname -r)
 
   AC_ARG_WITH(kerneldir,
     [  --with-kerneldir=DIR    kernel sources in DIR],
 
     ac_kerneldir=${withval}
+
+    if test -n "$ac_kerneldir" ; then
+	if test ! ${ac_kerneldir#/lib/modules} = ${ac_kerneldir} ; then
+	    kernelvers=$(basename $(dirname ${ac_kerneldir}))
+	elif test ! ${ac_kerneldir#*linux-headers-} = ${ac_kerneldir} ; then
+	    # special case to deal with the way the travis script does headers
+	    kernelvers=${ac_kerneldir#*linux-headers-}
+	else
+	    kernelvers=$(make -s kernelrelease -C ${ac_kerneldir} M=dummy 2>/dev/null)
+	fi
+    fi
+
     AC_PATH_KERNEL_SOURCE_SEARCH,
 
     ac_kerneldir=""
@@ -61,6 +74,11 @@ AC_DEFUN([AC_PATH_KERNEL_SOURCE],
 
   AC_SUBST(kerneldir)
   AC_SUBST(kernelext)
+  AC_SUBST(kernelvers)
   AC_MSG_RESULT(${kerneldir})
+
+  AC_MSG_CHECKING([kernel release])
+  AC_MSG_RESULT([${kernelvers}])
+
 ]
 )


### PR DESCRIPTION
This commit changes the directory where the xpmem module is. If no
kernel source directory is specified (build for current running
release) then linux_release is set from uname -r. If a kernel source
directory is specified the release is taken from the directory name if
the source specified is /lib/modules/release/build or
/lib/modules/release/source or from make kernel_release otherwise.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>