### PR TITLE
kernel: fix build with linux v4.8

### DIFF
--- a/kernel/xpmem_pfn.c
+++ b/kernel/xpmem_pfn.c
@@ -226,13 +226,15 @@ xpmem_pin_page(struct xpmem_thread_group *tg, struct task_struct *src_task,
 		set_cpus_allowed_ptr(current, cpumask_of(task_cpu(src_task)));
 	}
 
-	/* get_user_pages() faults and pins the page */
+	/* get_user_pages()/get_user_pages_remote() faults and pins the page */
 #if   LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0)
         ret = get_user_pages_remote (src_task, src_mm, vaddr, 1, FOLL_WRITE | FOLL_FORCE,
                                      &page, NULL, NULL);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
 	ret = get_user_pages_remote (src_task, src_mm, vaddr, 1, FOLL_WRITE | FOLL_FORCE,
 				     &page, NULL);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
+	ret = get_user_pages_remote (src_task, src_mm, vaddr, 1, 1, 1, &page, NULL);
 #else
 	ret = get_user_pages (src_task, src_mm, vaddr, 1, 1, 1, &page, NULL);
 #endif


### PR DESCRIPTION
The removal of the task argument to get_user_pages() happened before
v4.9. This commit adds a fix that fixes builds on v4.8 which does not
have the task argument to get_user_pages() but has not combined the
write and force flags.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>