### PR TITLE
Update XPMEM to work with Linux kernels up to v5.3

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,22 @@
+name: C/C++ CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: autogen
+      run: ./autogen.sh
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+# distcheck is currently broken
+#    - name: make distcheck
+#     run: make distcheck

--- a/kernel/xpmem_mmu_notifier.c
+++ b/kernel/xpmem_mmu_notifier.c
@@ -65,10 +65,20 @@ xpmem_invalidate_PTEs_range(struct xpmem_thread_group *seg_tg,
  * XPMEM only uses the invalidate_range_end() portion. That is, when all pages
  * in the range have been unmapped and the pages have been freed by the VM.
  */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
 static void
 xpmem_invalidate_range(struct mmu_notifier *mn, struct mm_struct *mm,
 		       unsigned long start, unsigned long end)
 {
+#else
+static void
+xpmem_invalidate_range(struct mmu_notifier *mn,
+	               const struct mmu_notifier_range *mnr)
+{
+	struct mm_struct *mm = mnr->mm;
+	unsigned long start  = mnr->start;
+	unsigned long end    = mnr->end;
+#endif
 	struct xpmem_thread_group *seg_tg;
 	struct vm_area_struct *vma;
 

--- a/kernel/xpmem_pfn.c
+++ b/kernel/xpmem_pfn.c
@@ -249,7 +249,11 @@ xpmem_pin_page(struct xpmem_thread_group *tg, struct task_struct *src_task,
 	 */
 	if (xpmem_vaddr_to_pte_offset(src_mm, vaddr, NULL) == NULL &&
 	    cpu_to_node(task_cpu(current)) != cpu_to_node(task_cpu(src_task))) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 3, 0)
+		saved_mask = current->cpus_mask;
+#else
 		saved_mask = current->cpus_allowed;
+#endif
 		set_cpus_allowed_ptr(current, cpumask_of(task_cpu(src_task)));
 	}
 


### PR DESCRIPTION
Tested with Ubuntu LTS running Linux v5.0 and v5.3 kernels.