### PR TITLE
kernel: fix bus error during mm fault

### DIFF
--- a/kernel/xpmem_attach.c
+++ b/kernel/xpmem_attach.c
@@ -292,11 +292,9 @@ xpmem_fault_handler(struct vm_area_struct *vma, struct vm_fault *vmf)
 	seg_vaddr = (att->vaddr & PAGE_MASK) + (vaddr - att->at_vaddr);
 	XPMEM_DEBUG("vaddr = %llx, seg_vaddr = %llx", vaddr, seg_vaddr);
 
-        ret = xpmem_ensure_valid_PFN(seg, seg_vaddr);
+        ret = xpmem_ensure_valid_PFN(seg, seg_vaddr, &pfn);
         if (ret != 0)
 		goto out_2;
-
-	pfn = xpmem_vaddr_to_PFN(seg_tg->mm, seg_vaddr);
 
 	att->flags |= XPMEM_FLAG_VALIDPTEs;
 
@@ -354,6 +352,10 @@ out:
         xpmem_tg_deref(seg_tg);
         xpmem_seg_deref(seg);
 	xpmem_att_deref(att);
+
+	if (ret == VM_FAULT_SIGBUS) {
+		XPMEM_DEBUG("fault returning SIGBUS vaddr=%llx, pfn=%lx", vaddr, pfn);
+	}
 
 	return ret;
 }

--- a/kernel/xpmem_private.h
+++ b/kernel/xpmem_private.h
@@ -285,7 +285,7 @@ extern void xpmem_detach_att(struct xpmem_access_permit *,
 extern int xpmem_mmap(struct file *, struct vm_area_struct *);
 
 /* found in xpmem_pfn.c */
-extern int xpmem_ensure_valid_PFN(struct xpmem_segment *, u64);
+extern int xpmem_ensure_valid_PFN(struct xpmem_segment *, u64, unsigned long *);
 extern u64 xpmem_vaddr_to_PFN(struct mm_struct *mm, u64 vaddr);
 extern int xpmem_block_recall_PFNs(struct xpmem_thread_group *, int);
 extern void xpmem_unpin_pages(struct xpmem_segment *, struct mm_struct *, u64,


### PR DESCRIPTION
in some cases after xpmem_ensure_valid_PFN() returns druing mm fault,
the PTE followed by virtual address may be not present. As a result,
PFN is 0 and the user application fails with SIGBUS. Instead take
the PFN from 'struct page' as returned from get_user_pages().