### PR TITLE
Add missing include of slab.h

### DIFF
--- a/kernel/xpmem_attach.c
+++ b/kernel/xpmem_attach.c
@@ -20,6 +20,7 @@
 #include <linux/mm.h>
 #include <linux/mman.h>
 #include <linux/file.h>
+#include <linux/slab.h>
 #include "xpmem_internal.h"
 #include "xpmem_private.h"
 

--- a/kernel/xpmem_get.c
+++ b/kernel/xpmem_get.c
@@ -13,6 +13,7 @@
 
 #include <linux/err.h>
 #include <linux/mm.h>
+#include <linux/slab.h>
 #include <linux/stat.h>
 #include "xpmem_internal.h"
 #include "xpmem_private.h"

--- a/kernel/xpmem_main.c
+++ b/kernel/xpmem_main.c
@@ -29,6 +29,7 @@
 #include <linux/mm.h>
 #include <linux/file.h>
 #include <linux/proc_fs.h>
+#include <linux/slab.h>
 #include "xpmem_internal.h"
 #include "xpmem_private.h"
 

--- a/kernel/xpmem_make.c
+++ b/kernel/xpmem_make.c
@@ -16,6 +16,7 @@
 
 #include <linux/err.h>
 #include <linux/mm.h>
+#include <linux/slab.h>
 #include "xpmem_internal.h"
 #include "xpmem_private.h"
 

--- a/kernel/xpmem_misc.c
+++ b/kernel/xpmem_misc.c
@@ -15,6 +15,7 @@
 #include <linux/mm.h>
 #include <linux/proc_fs.h>
 #include <linux/seq_file.h>
+#include <linux/slab.h>
 #include <linux/uaccess.h>
 #include <xpmem.h>
 #include "xpmem_private.h"


### PR DESCRIPTION
Fixes errors of missing kzalloc and kfree with some specific kernel
configurations.

Signed-off-by: Tzafrir Cohen <nvidia@cohens.org.il>