### PR TITLE
Fix memory leak of xpmem_thread_group and related objects

### DIFF
--- a/kernel/xpmem_mmu_notifier.c
+++ b/kernel/xpmem_mmu_notifier.c
@@ -167,20 +167,19 @@ xpmem_mmu_release(struct mmu_notifier *mn, struct mm_struct *mm)
 	 * Some other process may be the last to release the mm, so
 	 * validate it against the value stored in the tg before continuing.
 	 */
-	tg = xpmem_tg_ref_by_tgid(current->tgid);
-	if (!IS_ERR(tg)) {
-		if (tg->mm == mm) {
-			/*
-			 * Normal case, process is removing its own address
-			 * space.
-			 */
-			XPMEM_DEBUG("self: tg->mm=%p", tg->mm);
-			xpmem_teardown(tg);
-			return;
-		} else {
-			/* Abnormal case, must continue with code below. */
-			xpmem_tg_deref(tg);
-		}
+	tg = container_of(mn, struct xpmem_thread_group, mmu_not);
+	xpmem_tg_ref(tg);
+	if (tg->mm == mm) {
+		/*
+		 * Normal case, process is removing its own address
+		 * space.
+		 */
+		XPMEM_DEBUG("self: tg->mm=%p", tg->mm);
+		xpmem_teardown(tg);
+		return;
+	} else {
+		/* Abnormal case, must continue with code below. */
+		xpmem_tg_deref(tg);
 	}
 
 	/*


### PR DESCRIPTION
Memory leak occurs when close(2) is called explicitly from
a user application due to the following reason:
close(2) deletes tg from tg_hashtable in xpmem_flush() and after that
xpmem_mmu_release() is unable to find the tg from the list and
fails to call xpmem_teardown().

tg can be referenced with a mmu_notifier object in xpmem_mmu_release()
instead of searching for the tg from the list.

I attach a reproducer.

How to run:

```
# mv reproducer.c.txt reproducer.c
# gcc -o reproducer reproducer.c -lxpmem
# ./reproducer
# cat /proc/xpmem/global_pages
```

Check whether "all pages pinned by XPMEM" equals to "all pages unpinned by XPMEM".

Before:

```
# ./reproducer > /dev/null
# cat /proc/xpmem/global_pages
all pages pinned by XPMEM: 30
all pages unpinned by XPMEM: 0
```

After:

```
# ./reproducer > /dev/null
# cat /proc/xpmem/global_pages
all pages pinned by XPMEM: 30
all pages unpinned by XPMEM: 30
```

[reproducer.c.txt](https://github.com/hjelmn/xpmem/files/7183874/reproducer.c.txt)
