### PR TITLE
Remove unnecessary spinlock.

### DIFF
--- a/kernel/xpmem_main.c
+++ b/kernel/xpmem_main.c
@@ -109,12 +109,10 @@ xpmem_open(struct inode *inode, struct file *file)
 	}
 
 	snprintf(tgid_string, XPMEM_TGID_STRING_LEN, "%d", current->tgid);
-	spin_lock(&xpmem_unpin_procfs_lock);
 	unpin_entry = proc_create_data(tgid_string, 0644,
 				       xpmem_unpin_procfs_dir,
 				       &xpmem_unpin_procfs_ops,
 				       (void *)(unsigned long)current->tgid);
-	spin_unlock(&xpmem_unpin_procfs_lock);
 	if (unpin_entry != NULL) {
 		proc_set_user(unpin_entry, current_uid(), current_gid());
 	}
@@ -257,9 +255,7 @@ xpmem_flush(struct file *file, fl_owner_t owner)
 	 * and the distruction of the thread group object.
 	 */
 	snprintf(tgid_string, XPMEM_TGID_STRING_LEN, "%d", tg->tgid);
-	spin_lock(&xpmem_unpin_procfs_lock);
 	remove_proc_entry(tgid_string, xpmem_unpin_procfs_dir);
-	spin_unlock(&xpmem_unpin_procfs_lock);
 
 	xpmem_destroy_tg(tg);
 
@@ -419,7 +415,6 @@ xpmem_init(void)
 	}
 
 	/* create the /proc interface directory (/proc/xpmem) */
-	spin_lock_init(&xpmem_unpin_procfs_lock);
 	xpmem_unpin_procfs_dir = proc_mkdir(XPMEM_MODULE_NAME, NULL);
 	if (xpmem_unpin_procfs_dir == NULL) {
 		ret = -EBUSY;

--- a/kernel/xpmem_pfn.c
+++ b/kernel/xpmem_pfn.c
@@ -545,7 +545,6 @@ xpmem_fork_end(void)
 	return 0;
 }
 
-spinlock_t xpmem_unpin_procfs_lock;
 struct proc_dir_entry *xpmem_unpin_procfs_dir;
 
 static int

--- a/kernel/xpmem_private.h
+++ b/kernel/xpmem_private.h
@@ -294,7 +294,6 @@ extern void xpmem_unblock_recall_PFNs(struct xpmem_thread_group *);
 extern int xpmem_fork_begin(void);
 extern int xpmem_fork_end(void);
 #define XPMEM_TGID_STRING_LEN	11
-extern spinlock_t xpmem_unpin_procfs_lock;
 extern struct proc_dir_entry *xpmem_unpin_procfs_dir;
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,6,0)
 extern struct file_operations xpmem_unpin_procfs_ops;


### PR DESCRIPTION
Spinlock is acquired before calling proc_create_data(). That may
cause deadlock because proc_create_data() may call schedule().

It seems to me that acquiring xpmem_unpin_procfs_lock is not necessary because
proc_create_data() and remove_proc_entry() acquire their own lock internally, and 
the arguments (tgid_string, xpmem_unpin_procfs_dir, xpmem_unpin_procfs_ops, current->tgid)
won't be updated from other context. 

If we really need to acquire a lock, please consider using mutex_lock instead of spin_lock.