### PR TITLE
Resolve build errors on kernel 6.1 and higher

### DIFF
--- a/kernel/xpmem_attach.c
+++ b/kernel/xpmem_attach.c
@@ -507,7 +507,7 @@ xpmem_attach(struct file *file, xpmem_apid_t apid, off_t offset, size_t size,
 						     vaddr + size);
 		xpmem_mmap_write_unlock(current->mm);
 		for ( ; existing_vma && existing_vma->vm_start < vaddr + size
-				; existing_vma = existing_vma->vm_next) {
+				; existing_vma = find_vma(current->mm, existing_vma->vm_end)) {
 			if (xpmem_is_vm_ops_set(existing_vma)) {
 				ret = -EINVAL;
 				goto out_3;

--- a/kernel/xpmem_attach.c
+++ b/kernel/xpmem_attach.c
@@ -527,8 +527,15 @@ xpmem_attach(struct file *file, xpmem_apid_t apid, off_t offset, size_t size,
 	xpmem_mmap_write_unlock(current->mm);
 
 	vma->vm_private_data = att;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
 	vm_flags_set(vma,
 		VM_DONTCOPY | VM_DONTDUMP | VM_IO | VM_DONTEXPAND | VM_PFNMAP);
+#else
+	vma->vm_flags |=
+	    VM_DONTCOPY | VM_DONTDUMP | VM_IO | VM_DONTEXPAND | VM_PFNMAP;
+#endif
+
 	vma->vm_ops = &xpmem_vm_ops;
 
 	att->at_vma = vma;

--- a/kernel/xpmem_attach.c
+++ b/kernel/xpmem_attach.c
@@ -527,8 +527,8 @@ xpmem_attach(struct file *file, xpmem_apid_t apid, off_t offset, size_t size,
 	xpmem_mmap_write_unlock(current->mm);
 
 	vma->vm_private_data = att;
-	vma->vm_flags |=
-	    VM_DONTCOPY | VM_DONTDUMP | VM_IO | VM_DONTEXPAND | VM_PFNMAP;
+	vm_flags_set(vma,
+		VM_DONTCOPY | VM_DONTDUMP | VM_IO | VM_DONTEXPAND | VM_PFNMAP);
 	vma->vm_ops = &xpmem_vm_ops;
 
 	att->at_vma = vma;

--- a/kernel/xpmem_mmu_notifier.c
+++ b/kernel/xpmem_mmu_notifier.c
@@ -109,7 +109,7 @@ xpmem_invalidate_range(struct mmu_notifier *mn,
 		return;
 	}
 
-	for ( ; vma && vma->vm_start < end; vma = vma->vm_next) {
+	for ( ; vma && vma->vm_start < end; vma = find_vma(mm, vma->vm_end)) {
 		unsigned long vm_start;
 		unsigned long vm_end;
 


### PR DESCRIPTION
The struct `vm_area_struct` has been changed in commits [763ecb0](https://github.com/torvalds/linux/commit/763ecb035029f500d7e6dc99acd1ad299b7726a1#diff-dc57f7b72015cf5f95444ec4f8a60f85d773f40b96ac59bf55b281cd63c06142) and [bc292ab](https://github.com/torvalds/linux/commit/bc292ab00f6c7a661a8a605c714e8a148f629ef6#diff-dc57f7b72015cf5f95444ec4f8a60f85d773f40b96ac59bf55b281cd63c06142). These changes remove the VMA linked list and set the `vm_flags` member to private, respectively. The two commits in this pull request adapt the XPMEM code base to these changes.

The first commit replaces references to the now-deleted member `vm_next` with the function call `find_vma()`.
The second commit replaces one OR operation to `vm_flags` with the introduced wrapper function `vm_flags_set()`, which internally ORs the member.

The changes have been tested on a kernel 6.4.3, the included test, invoked by `make check` passes. Backwards compatibility was tested on kernel version 4.18.0.
This resolves Issue #62. 