### PR TITLE
Solve build errors on kernel 6.9 and higher

### DIFF
--- a/kernel/xpmem_pfn.c
+++ b/kernel/xpmem_pfn.c
@@ -45,9 +45,14 @@
 #define pud_is_huge(p) (0)
 #endif
 #elif defined(CONFIG_X86)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,9,0)
 #define pmd_is_huge(p) pmd_large(p)
 #define pud_is_huge(p) pud_large(p)
-#elif defined(CONFIG_PPC)
+#else
+#define pmd_is_huge(p) pmd_leaf(p)
+#define pud_is_huge(p) pud_leaf(p)
+#endif// LINUX_VERSION_CODE
+#elif defined(CONFIG_PPC)//TODO: check symbol change for powerpc
 #define pmd_is_huge(p) pmd_large(p)
 #define pud_is_huge(p) ((pud_val(p) & 0x3) != 0x0)
 #else


### PR DESCRIPTION

    In kernel commit 902861e34c401696ed9ad17a54c8790e7e8e3069, `pmd_large` and
    `pud_large` was renamed to `pmd_leaf` and `pud_leaf` by patch from redhat.

    This patch applies this change to xpmem.

    Symbols for PowerPC was also renamed in the same kernel commit. As
    author of this patch knows none about the reason of redirecting `pud_is_large`
    to something other than `pud_large`, the PPC part is unchanged.
